### PR TITLE
Enforce invalid date status in teacher list test

### DIFF
--- a/tests/integration/curl/03-teacher-list.sh
+++ b/tests/integration/curl/03-teacher-list.sh
@@ -43,6 +43,10 @@ if [ "${RUN_INVALID_DATE_CHECK:-0}" != "0" ]; then
     -H "Cookie: $COOKIE" \
     -H "Accept: application/json")
   echo "Invalid date check status (expected 400): ${invalid_status}"
+  if [ "${invalid_status}" != "400" ]; then
+    echo "Unexpected status for invalid date: ${invalid_status}" >&2
+    exit 1
+  fi
 fi
 
 echo "[Done] conversation list fetched."


### PR DESCRIPTION
## Summary
- ensure the teacher list curl test fails when the invalid date response is not HTTP 400

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fcc21478483318005211b3ffb4fd3)