### PR TITLE
教学分析简化:按教师工作流重组为 诊断→回顾清单→学生问题→课后作业

### DIFF
--- a/docs/superpowers/specs/2026-04-12-teaching-analysis-redesign.md
+++ b/docs/superpowers/specs/2026-04-12-teaching-analysis-redesign.md
@@ -4,6 +4,19 @@
 **Scope:** Full redesign (UI, rule engine, LLM prompt)
 **Status:** Approved
 
+> **Addendum 2026-07-03 — 简化修订（teacher-feedback driven）**
+> 教师反馈：发现项重复、报告过长难抓重点、部分卡片展开无内容。此次修订：
+> 1. 新增 `findingConsolidator`：errorCluster 并入同题 commonError（保留错误签名/代码样本），
+>    学生集合被覆盖的 crossCorrelation 折叠为宿主发现的 `supplements`；按严重度+影响面排序，
+>    超出前 5 条标记 `isSecondary`（UI 中"其他观察"一行带过），progress 固定为正向横幅。
+> 2. 主 LLM 报告砍掉 `p0_action_plan` 章节（与发现卡片+深度诊断重复），只保留
+>    一句话诊断 / 下节课回顾清单 / 个体干预建议；深度诊断仅对重点发现执行。
+> 3. 挖空作业独立存储（`homeworkText`），UI 作为"课后强化训练"板块一键复制下发；
+>    只要存在共性错误，保底为影响面最大的题目生成作业。
+> 4. 发现项附带 `studentNames`（uid→用户名），展开卡片可见涉及学生名单；
+>    无实际详情的卡片不再显示展开箭头。
+> 页面结构调整为教师备课工作流：诊断 → 下节课回顾清单 → 学生问题 → 课后强化训练。
+
 ---
 
 ## 1. Overview

--- a/frontend/teachingSummary/TeachingSummaryPanel.tsx
+++ b/frontend/teachingSummary/TeachingSummaryPanel.tsx
@@ -1,6 +1,10 @@
 /**
  * TeachingSummaryPanel — teacher-facing UI for AI teaching summary generation.
  * Injects into homework/contest scoreboard pages for whole-class analysis.
+ *
+ * 完成态按教师备课工作流组织为四段：
+ * ① 一句话诊断 → ② 下节课回顾清单（含个体干预）→ ③ 学生问题（重点卡片 + 其他观察）
+ * → ④ 课后强化训练（可一键复制下发）
  */
 
 import React, { useState, useEffect, useCallback } from 'react';
@@ -23,17 +27,26 @@ const I18N_FALLBACK: Record<string, string> = {
   ai_helper_teaching_summary_focus_placeholder: '可选：输入教学重点（如"递归理解"或"复杂度优化"）',
   ai_helper_teaching_summary_snapshot_notice: '数据快照时间：',
   ai_helper_teaching_summary_participated: '参与学生',
-  ai_helper_teaching_summary_findings: '发现项',
+  ai_helper_teaching_summary_primary_findings: '重点问题',
   ai_helper_teaching_summary_high_priority: '高优先级',
   ai_helper_teaching_summary_ai_users: 'AI 使用者',
+  ai_helper_teaching_summary_completed_all: '完成全部题目',
   ai_helper_teaching_summary_low_data_warning: '参与学生不足 10 人，分析结果仅供参考。',
-  ai_helper_teaching_summary_findings_title: '教学发现',
+  ai_helper_teaching_summary_section_diagnosis: '一句话诊断',
+  ai_helper_teaching_summary_section_review: '下节课回顾清单',
+  ai_helper_teaching_summary_section_problems: '学生问题',
+  ai_helper_teaching_summary_section_homework: '课后强化训练',
+  ai_helper_teaching_summary_section_full_report: 'AI 完整报告',
+  ai_helper_teaching_summary_other_observations: '其他观察',
   ai_helper_teaching_summary_no_findings: '未发现明显问题',
   ai_helper_teaching_summary_overall_suggestion: 'AI 综合建议',
-  ai_helper_teaching_summary_expand: '展开',
-  ai_helper_teaching_summary_collapse: '收起',
   ai_helper_teaching_summary_affected: '涉及',
   ai_helper_teaching_summary_students: '名学生',
+  ai_helper_teaching_summary_student_list: '涉及学生',
+  ai_helper_teaching_summary_copy_homework: '复制作业',
+  ai_helper_teaching_summary_copied: '已复制',
+  ai_helper_teaching_summary_copy_failed: '复制失败，请手动选择文本复制',
+  ai_helper_teaching_summary_homework_hint: '可直接复制下发（"建议挖空点说明"为教师参考答案，请勿下发）',
   ai_helper_teaching_summary_feedback_helpful: '有帮助',
   ai_helper_teaching_summary_feedback_not_helpful: '没帮助',
   ai_helper_teaching_summary_feedback_thanks: '感谢反馈！',
@@ -73,11 +86,6 @@ const METRIC_LABELS: Record<string, string> = {
   passRate: '通过率',
   attempted: '尝试人数',
   accepted: '通过人数',
-  affectedCount: '受影响人数',
-  totalStudents: '总学生数',
-  percentage: '占比',
-  atRiskCount: '高危人数',
-  completedCount: '完成人数',
   comprehensionPct: '理解类提问占比',
   aiUserCount: 'AI 使用人数',
   nonAiUserCount: '未使用 AI 人数',
@@ -90,10 +98,7 @@ const METRIC_LABELS: Record<string, string> = {
   aiPassRate: 'AI 用户通过率',
   nonAiPassRate: '非 AI 通过率',
   diff: '差异',
-  burst_then_quit: '受挫放弃',
-  stuck_silent: '沉默挣扎',
-  persistent_learner: '持续努力',
-  disengaged: '未参与',
+  sameSignatureCount: '同一错误位学生数',
   aiGroupSize: 'AI组人数',
   nonAiGroupSize: '非AI组人数',
   aiACRate: 'AI组通过率',
@@ -102,11 +107,83 @@ const METRIC_LABELS: Record<string, string> = {
   dominantClusterPct: '主要错误集群占比',
 };
 
+/** 这些指标与卡片标题/"涉及 N 名学生"徽标重复，展开时不再显示 */
+const REDUNDANT_METRICS = new Set([
+  'affectedCount', 'totalStudents', 'percentage',
+  'atRiskCount', 'completedCount',
+]);
+
+/** 百分比类指标，展示时补 % 号 */
+const PERCENT_METRIC = /rate|pct|percentage/i;
+
 const SEVERITY_COLORS = {
   high: { bg: '#fef2f2', text: '#b91c1c', border: '#fecaca' },
   medium: { bg: '#fffbeb', text: '#92400e', border: '#fde68a' },
   low: { bg: '#f0fdf4', text: '#166534', border: '#bbf7d0' },
 };
+
+/** 学生名单默认展示上限，超出折叠为 +N */
+const MAX_VISIBLE_NAMES = 24;
+
+// ─── overallSuggestion 分段解析 ───────────────────────────────────────────────
+//
+// 主报告是一段 markdown，按 "### " 标题切块归类；识别失败的块进入 rest，
+// 由"AI 完整报告"折叠区兜底（兼容旧版含 P0 报告/作业的长文档）。
+
+export interface ParsedSuggestion {
+  diagnosis?: string;
+  reviewList?: string;
+  p1?: string;
+  homework?: string;
+  rest: string[];
+}
+
+export function parseSuggestionSections(md: string): ParsedSuggestion {
+  const result: ParsedSuggestion = { rest: [] };
+  if (!md || !md.trim()) return result;
+
+  const chunks = md.split(/(?=^###\s)/m).filter(c => c.trim());
+  for (const chunk of chunks) {
+    const firstLine = chunk.split('\n', 1)[0];
+    const body = chunk.replace(/^###[^\n]*\n?/, '').trim();
+    if (/一句话诊断/.test(firstLine) && !result.diagnosis) {
+      result.diagnosis = body;
+    } else if (/下节课回顾清单/.test(firstLine) && !result.reviewList) {
+      result.reviewList = body;
+    } else if (/个体干预/.test(firstLine) && !result.p1) {
+      result.p1 = body;
+    } else if (/课后巩固|挖空练习/.test(firstLine) && !result.homework) {
+      result.homework = chunk.trim();
+    } else {
+      result.rest.push(chunk.trim());
+    }
+  }
+  return result;
+}
+
+// ─── 剪贴板 ───────────────────────────────────────────────────────────────────
+
+async function copyText(text: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch { /* fall through to legacy path */ }
+  try {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.style.position = 'fixed';
+    ta.style.opacity = '0';
+    document.body.appendChild(ta);
+    ta.select();
+    const ok = document.execCommand('copy');
+    document.body.removeChild(ta);
+    return ok;
+  } catch {
+    return false;
+  }
+}
 
 // ─── SkeletonBlock subcomponent ───────────────────────────────────────────────
 
@@ -131,18 +208,85 @@ const SkeletonBlock: React.FC<{ lines?: number }> = ({ lines = 8 }) => (
   </div>
 );
 
+// ─── Section shell ────────────────────────────────────────────────────────────
+
+interface SectionCardProps {
+  icon: string;
+  title: string;
+  accentColor?: string;
+  headerRight?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+const SectionCard: React.FC<SectionCardProps> = ({
+  icon, title, accentColor = COLORS.border, headerRight, children,
+}) => (
+  <div style={{
+    border: `1px solid ${COLORS.border}`,
+    borderLeft: `4px solid ${accentColor}`,
+    borderRadius: RADIUS.md,
+    backgroundColor: COLORS.bgCard,
+    boxShadow: SHADOWS.sm,
+    marginBottom: SPACING.lg,
+    overflow: 'hidden',
+  }}>
+    <div style={{
+      display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+      gap: SPACING.sm,
+      padding: `${SPACING.md} ${SPACING.base}`,
+      borderBottom: `1px solid ${COLORS.border}`,
+      backgroundColor: COLORS.bgPage,
+    }}>
+      <span style={{
+        fontWeight: 600, fontSize: '13px', color: COLORS.textSecondary,
+        letterSpacing: '0.05em',
+      }}>
+        {icon} {title}
+      </span>
+      {headerRight}
+    </div>
+    <div style={{ padding: `${SPACING.md} ${SPACING.base}` }}>
+      {children}
+    </div>
+  </div>
+);
+
 // ─── FindingCard subcomponent ─────────────────────────────────────────────────
 
 interface FindingCardProps {
   finding: TeachingFinding;
   deepDiveText?: string;
+  studentNames?: Record<string, string>;
 }
 
-const FindingCard: React.FC<FindingCardProps> = ({ finding, deepDiveText }) => {
+const FindingCard: React.FC<FindingCardProps> = ({ finding, deepDiveText, studentNames }) => {
   const [expanded, setExpanded] = useState(false);
+  const [showAllNames, setShowAllNames] = useState(false);
   const colors = SEVERITY_COLORS[finding.severity] || SEVERITY_COLORS.low;
   const dimensionLabel = DIMENSION_LABELS[finding.dimension] || finding.dimension;
   const affectedCount = finding.evidence.affectedStudents.length;
+
+  const names = (finding.evidence.affectedStudents || [])
+    .map(uid => studentNames?.[String(uid)])
+    .filter(Boolean) as string[];
+
+  const extraMetrics = Object.entries(finding.evidence.metrics || {})
+    .filter(([key]) => !REDUNDANT_METRICS.has(key));
+
+  const codeSample = (finding.dimension === 'commonError' || finding.dimension === 'errorCluster')
+    ? finding.evidence.samples?.code?.[0]
+    : undefined;
+
+  // 展开必须有实际内容；否则整行不可点，避免"展开什么也没有"
+  const hasDetails = Boolean(
+    (finding.supplements && finding.supplements.length > 0)
+    || deepDiveText
+    || codeSample
+    || names.length > 0
+    || extraMetrics.length > 0,
+  );
+
+  const visibleNames = showAllNames ? names : names.slice(0, MAX_VISIBLE_NAMES);
 
   return (
     <div style={{
@@ -155,11 +299,11 @@ const FindingCard: React.FC<FindingCardProps> = ({ finding, deepDiveText }) => {
       transition: 'box-shadow 200ms ease',
     }}>
       <div
-        onClick={() => setExpanded(!expanded)}
+        onClick={hasDetails ? () => setExpanded(!expanded) : undefined}
         style={{
           display: 'flex', alignItems: 'center', gap: SPACING.sm,
           padding: `${SPACING.md} ${SPACING.base}`,
-          cursor: 'pointer', userSelect: 'none',
+          cursor: hasDetails ? 'pointer' : 'default', userSelect: 'none',
         }}
       >
         <span style={{
@@ -204,47 +348,43 @@ const FindingCard: React.FC<FindingCardProps> = ({ finding, deepDiveText }) => {
           {t('ai_helper_teaching_summary_affected')} {affectedCount} {t('ai_helper_teaching_summary_students')}
         </span>
 
-        <span style={{
-          display: 'inline-block', width: '16px', height: '16px', flexShrink: 0,
-          textAlign: 'center', lineHeight: '16px', fontSize: '12px',
-          color: COLORS.textMuted,
-          transition: 'transform 200ms ease',
-          transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)',
-        }}>▶</span>
+        {hasDetails && (
+          <span style={{
+            display: 'inline-block', width: '16px', height: '16px', flexShrink: 0,
+            textAlign: 'center', lineHeight: '16px', fontSize: '12px',
+            color: COLORS.textMuted,
+            transition: 'transform 200ms ease',
+            transform: expanded ? 'rotate(90deg)' : 'rotate(0deg)',
+          }}>▶</span>
+        )}
       </div>
 
-      {expanded && (
+      {expanded && hasDetails && (
         <div style={{
           padding: `0 ${SPACING.base} ${SPACING.base}`,
           borderTop: `1px solid ${COLORS.border}`,
           paddingTop: SPACING.md,
         }}>
-          {Object.keys(finding.evidence.metrics).length > 0 && (
+          {/* 关联洞察（合并进来的交叉关联/错误聚类补充） */}
+          {finding.supplements && finding.supplements.length > 0 && (
             <div style={{
-              display: 'flex', flexWrap: 'wrap', gap: SPACING.sm,
               marginBottom: SPACING.md,
               padding: `${SPACING.sm} ${SPACING.md}`,
               backgroundColor: COLORS.bgPage,
+              borderLeft: `3px solid ${COLORS.textMuted}`,
               borderRadius: RADIUS.sm,
             }}>
-              {Object.entries(finding.evidence.metrics).map(([key, val]) => (
-                <span key={key} style={{
-                  fontSize: '12px', color: COLORS.textSecondary,
+              {finding.supplements.map((s, i) => (
+                <div key={i} style={{
+                  fontSize: '13px', color: COLORS.textSecondary, lineHeight: 1.6,
                 }}>
-                  <span style={{ color: COLORS.textMuted }}>{METRIC_LABELS[key] || key}:</span>{' '}
-                  <strong>{typeof val === 'number' ? (val % 1 === 0 ? val : val.toFixed(2)) : val}</strong>
-                </span>
+                  ↳ {s}
+                </div>
               ))}
             </div>
           )}
 
-          {finding.aiSuggestion && (
-            <div style={{ fontSize: '13px', color: COLORS.textSecondary, marginBottom: SPACING.md, lineHeight: 1.6 }}>
-              <strong>{DIMENSION_LABELS[finding.dimension] || finding.dimension}：</strong>
-              {finding.aiSuggestion}
-            </div>
-          )}
-
+          {/* 深度诊断（根因 + 反例 + 课堂提问） */}
           {deepDiveText && (
             <div
               className="markdown-body"
@@ -253,8 +393,8 @@ const FindingCard: React.FC<FindingCardProps> = ({ finding, deepDiveText }) => {
             />
           )}
 
-          {(finding.dimension === 'commonError' || finding.dimension === 'errorCluster')
-            && finding.evidence.samples?.code && finding.evidence.samples.code.length > 0 && (
+          {/* 典型错误代码 */}
+          {codeSample && (
             <div style={{ marginTop: SPACING.md }}>
               <div style={{
                 fontSize: '12px', fontWeight: 600, color: COLORS.textSecondary,
@@ -269,8 +409,64 @@ const FindingCard: React.FC<FindingCardProps> = ({ finding, deepDiveText }) => {
                 color: '#e2e8f0', lineHeight: 1.6,
                 fontFamily: "'SFMono-Regular', 'Menlo', 'Consolas', monospace",
               }}>
-                {finding.evidence.samples.code[0]}
+                {codeSample}
               </pre>
+            </div>
+          )}
+
+          {/* 涉及学生名单 — 教师可据此点名辅导 */}
+          {names.length > 0 && (
+            <div style={{ marginTop: SPACING.md }}>
+              <div style={{
+                fontSize: '12px', fontWeight: 600, color: COLORS.textSecondary,
+                marginBottom: SPACING.sm, letterSpacing: '0.02em',
+              }}>
+                {t('ai_helper_teaching_summary_student_list')}（{names.length}）：
+              </div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px' }}>
+                {visibleNames.map((name, i) => (
+                  <span key={i} style={{
+                    fontSize: '12px', padding: '2px 8px',
+                    backgroundColor: COLORS.bgPage,
+                    border: `1px solid ${COLORS.border}`,
+                    borderRadius: RADIUS.full,
+                    color: COLORS.textSecondary,
+                  }}>
+                    {name}
+                  </span>
+                ))}
+                {names.length > MAX_VISIBLE_NAMES && !showAllNames && (
+                  <span
+                    onClick={() => setShowAllNames(true)}
+                    style={{
+                      fontSize: '12px', padding: '2px 8px',
+                      borderRadius: RADIUS.full,
+                      color: COLORS.primary, cursor: 'pointer',
+                      border: `1px dashed ${COLORS.primary}`,
+                    }}
+                  >
+                    +{names.length - MAX_VISIBLE_NAMES}
+                  </span>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* 其余非冗余指标 */}
+          {extraMetrics.length > 0 && (
+            <div style={{
+              display: 'flex', flexWrap: 'wrap', gap: SPACING.sm,
+              marginTop: SPACING.md,
+            }}>
+              {extraMetrics.map(([key, val]) => (
+                <span key={key} style={{ fontSize: '12px', color: COLORS.textMuted }}>
+                  {METRIC_LABELS[key] || key}:{' '}
+                  <strong style={{ color: COLORS.textSecondary }}>
+                    {typeof val === 'number' ? (val % 1 === 0 ? val : val.toFixed(2)) : val}
+                    {typeof val === 'number' && PERCENT_METRIC.test(key) ? '%' : ''}
+                  </strong>
+                </span>
+              ))}
             </div>
           )}
         </div>
@@ -281,29 +477,25 @@ const FindingCard: React.FC<FindingCardProps> = ({ finding, deepDiveText }) => {
 
 // ─── Overview bar ─────────────────────────────────────────────────────────────
 
-interface OverviewBarProps {
-  stats: TeachingSummary['stats'];
-  findingsCount: number;
-  highCount: number;
+interface OverviewItem {
+  label: string;
+  value: React.ReactNode;
+  highlight?: boolean;
+  positive?: boolean;
 }
 
-const OverviewBar: React.FC<OverviewBarProps> = ({ stats, findingsCount, highCount }) => (
+const OverviewBar: React.FC<{ items: OverviewItem[] }> = ({ items }) => (
   <div style={{
     display: 'flex', flexWrap: 'wrap', gap: SPACING.lg,
     marginBottom: SPACING.base,
     padding: `${SPACING.sm} 0`,
   }}>
-    {[
-      { label: t('ai_helper_teaching_summary_participated'), value: stats.participatedStudents },
-      { label: t('ai_helper_teaching_summary_findings'), value: findingsCount },
-      { label: t('ai_helper_teaching_summary_high_priority'), value: highCount, highlight: highCount > 0 },
-      { label: t('ai_helper_teaching_summary_ai_users'), value: stats.aiUserCount },
-    ].map(({ label, value, highlight }) => (
+    {items.map(({ label, value, highlight, positive }) => (
       <span key={label} style={{ display: 'inline-flex', alignItems: 'baseline', gap: '4px' }}>
         <span style={{ fontSize: '12px', color: COLORS.textMuted }}>{label}</span>
         <span style={{
           fontSize: '18px', fontWeight: 700,
-          color: highlight ? COLORS.error : COLORS.textPrimary,
+          color: highlight ? COLORS.error : positive ? COLORS.hydroGreenDark : COLORS.textPrimary,
         }}>
           {value}
         </span>
@@ -326,16 +518,20 @@ export const TeachingSummaryPanel: React.FC<TeachingSummaryPanelProps> = ({ doma
 
   const [teachingFocus, setTeachingFocus] = useState('');
   const [feedbackSubmitted, setFeedbackSubmitted] = useState(false);
-  const [suggestionCollapsed, setSuggestionCollapsed] = useState(false);
+  const [fullReportCollapsed, setFullReportCollapsed] = useState(true);
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
 
   useEffect(() => {
     fetchSummary();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Report findings count to parent for tab badge
+  // Report primary problem count to parent for tab badge
   useEffect(() => {
     if (onStatsUpdate && summary?.findings) {
-      onStatsUpdate(summary.findings.length);
+      const primaryCount = summary.findings.filter(
+        f => !f.isSecondary && f.dimension !== 'progress',
+      ).length;
+      onStatsUpdate(primaryCount);
     }
   }, [summary?.findings?.length]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -468,13 +664,97 @@ export const TeachingSummaryPanel: React.FC<TeachingSummaryPanelProps> = ({ doma
   // ── Completed state ───────────────────────────────────────────────────────
 
   const findings = summary.findings || [];
-  const highFindings = findings.filter(f => f.severity === 'high');
-  const mediumFindings = findings.filter(f => f.severity === 'medium');
-  const lowFindings = findings.filter(f => f.severity === 'low');
+  const progressFinding = findings.find(f => f.dimension === 'progress');
+  const problemFindings = findings.filter(f => f.dimension !== 'progress');
+
+  // 后端已按严重度+影响面排序并标记次要发现；对旧文档做同样的客户端兜底限量
+  const flaggedPrimary = problemFindings.filter(f => !f.isSecondary);
+  const primaryFindings = flaggedPrimary.slice(0, 5);
+  const secondaryFindings = [
+    ...flaggedPrimary.slice(5),
+    ...problemFindings.filter(f => f.isSecondary),
+  ];
+
+  const highCount = primaryFindings.filter(f => f.severity === 'high').length;
+
+  const parsed = parseSuggestionSections(summary.overallSuggestion || '');
+  const parsedOk = Boolean(parsed.diagnosis || parsed.reviewList);
+  const homeworkMd = (summary.homeworkText && summary.homeworkText.trim())
+    ? summary.homeworkText
+    : parsed.homework;
 
   const snapshotDate = summary.dataSnapshotAt
     ? new Date(summary.dataSnapshotAt).toLocaleString('zh-CN', { hour12: false })
     : '';
+
+  const handleCopyHomework = async () => {
+    if (!homeworkMd) return;
+    const ok = await copyText(homeworkMd);
+    setCopyState(ok ? 'copied' : 'failed');
+    setTimeout(() => setCopyState('idle'), 2000);
+  };
+
+  const overviewItems: OverviewItem[] = [
+    {
+      label: t('ai_helper_teaching_summary_participated'),
+      value: `${summary.stats.participatedStudents}/${summary.stats.totalStudents}`,
+    },
+    {
+      label: t('ai_helper_teaching_summary_primary_findings'),
+      value: primaryFindings.length,
+    },
+    {
+      label: t('ai_helper_teaching_summary_high_priority'),
+      value: highCount,
+      highlight: highCount > 0,
+    },
+    ...(progressFinding ? [{
+      label: t('ai_helper_teaching_summary_completed_all'),
+      value: `${progressFinding.evidence.affectedStudents.length}${
+        typeof progressFinding.evidence.metrics?.percentage === 'number'
+          ? ` (${progressFinding.evidence.metrics.percentage}%)` : ''
+      }`,
+      positive: true,
+    }] : []),
+    {
+      label: t('ai_helper_teaching_summary_ai_users'),
+      value: summary.stats.aiUserCount,
+    },
+  ];
+
+  const feedbackRow = (
+    <div style={{
+      display: 'flex', alignItems: 'center', justifyContent: 'flex-end',
+      gap: SPACING.sm, padding: `${SPACING.sm} 0`,
+    }}>
+      {feedbackSubmitted ? (
+        <span style={{ fontSize: '12px', color: COLORS.successText }}>
+          {t('ai_helper_teaching_summary_feedback_thanks')}
+        </span>
+      ) : (
+        <>
+          {(['up', 'down'] as const).map(rating => (
+            <button
+              key={rating}
+              onClick={() => handleFeedback(rating)}
+              style={{
+                fontSize: '12px', padding: '3px 8px',
+                border: `1px solid ${COLORS.border}`,
+                borderRadius: RADIUS.sm,
+                backgroundColor: 'transparent',
+                color: summary.feedback?.rating === rating
+                  ? (rating === 'up' ? COLORS.successText : COLORS.errorText)
+                  : COLORS.textMuted,
+                cursor: 'pointer',
+              }}
+            >
+              {rating === 'up' ? t('ai_helper_teaching_summary_feedback_helpful') : t('ai_helper_teaching_summary_feedback_not_helpful')}
+            </button>
+          ))}
+        </>
+      )}
+    </div>
+  );
 
   return (
     <div style={{ fontFamily: 'inherit', color: COLORS.textPrimary, maxWidth: LAYOUT.contentMaxWidth, margin: '0 auto', width: '100%' }}>
@@ -519,11 +799,7 @@ export const TeachingSummaryPanel: React.FC<TeachingSummaryPanelProps> = ({ doma
       )}
 
       {/* Overview bar */}
-      <OverviewBar
-        stats={summary.stats}
-        findingsCount={findings.length}
-        highCount={highFindings.length}
-      />
+      <OverviewBar items={overviewItems} />
 
       {/* Low-data warning */}
       {summary.stats.participatedStudents < 10 && (
@@ -539,128 +815,202 @@ export const TeachingSummaryPanel: React.FC<TeachingSummaryPanelProps> = ({ doma
         </div>
       )}
 
-      {/* Single-column layout: Findings → AI Suggestion */}
-      <div>
-        {/* Findings */}
-        <div>
+      {/* ① 一句话诊断 — 30 秒抓住重点 */}
+      {parsed.diagnosis && (
+        <div style={{
+          padding: `${SPACING.base} ${SPACING.lg}`,
+          marginBottom: SPACING.lg,
+          backgroundColor: COLORS.bgCard,
+          border: `1px solid ${COLORS.border}`,
+          borderLeft: `4px solid ${COLORS.primary}`,
+          borderRadius: RADIUS.md,
+          boxShadow: SHADOWS.sm,
+        }}>
           <div style={{
-            fontWeight: 600, fontSize: '13px', marginBottom: SPACING.md,
-            color: COLORS.textMuted, textTransform: 'uppercase' as const,
-            letterSpacing: '0.05em',
+            fontSize: '12px', fontWeight: 600, color: COLORS.textMuted,
+            letterSpacing: '0.05em', marginBottom: SPACING.sm,
           }}>
-            {t('ai_helper_teaching_summary_findings_title')}
+            📊 {t('ai_helper_teaching_summary_section_diagnosis')}
           </div>
-
-          {findings.length === 0 ? (
-            <div style={{ color: COLORS.textMuted, fontSize: '13px', fontStyle: 'italic' }}>
-              {t('ai_helper_teaching_summary_no_findings')}
-            </div>
-          ) : (
-            <>
-              {highFindings.map(f => (
-                <FindingCard key={f.id} finding={f} deepDiveText={summary.deepDiveResults?.[f.id]} />
-              ))}
-              {mediumFindings.map(f => (
-                <FindingCard key={f.id} finding={f} deepDiveText={summary.deepDiveResults?.[f.id]} />
-              ))}
-              {lowFindings.map(f => (
-                <FindingCard key={f.id} finding={f} deepDiveText={summary.deepDiveResults?.[f.id]} />
-              ))}
-            </>
-          )}
+          <div
+            className="markdown-body"
+            style={{ fontSize: '15px', lineHeight: 1.7 }}
+            dangerouslySetInnerHTML={{ __html: renderMarkdown(parsed.diagnosis) }}
+          />
         </div>
+      )}
 
-        {/* AI Suggestion — collapsible conclusion card */}
-        {(summary.overallSuggestion || summary.status === 'generating') && (
-          <div style={{ marginTop: LAYOUT.sectionGap }}>
-            <div style={{
-              border: `1px solid ${COLORS.border}`,
-              borderLeft: `4px solid ${COLORS.hydroGreen}`,
-              borderRadius: RADIUS.md,
-              backgroundColor: COLORS.bgCard,
-              boxShadow: SHADOWS.sm,
-            }}>
-              {/* Clickable header */}
-              <div
-                onClick={() => setSuggestionCollapsed(!suggestionCollapsed)}
-                style={{
-                  padding: `${SPACING.md} ${SPACING.base}`,
-                  borderBottom: suggestionCollapsed ? 'none' : `1px solid ${COLORS.border}`,
-                  backgroundColor: COLORS.hydroGreenLight,
-                  cursor: 'pointer',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'space-between',
-                  userSelect: 'none' as const,
-                }}
-              >
-                <span style={{
-                  fontWeight: 600, fontSize: '13px', color: COLORS.hydroGreenDark,
-                  textTransform: 'uppercase' as const, letterSpacing: '0.05em',
-                }}>
-                  {t('ai_helper_teaching_summary_overall_suggestion')}
-                </span>
-                <span style={{
-                  display: 'inline-block', width: '16px', height: '16px',
-                  textAlign: 'center' as const, lineHeight: '16px', fontSize: '12px',
-                  color: COLORS.textMuted,
-                  transition: `transform ${TRANSITIONS.fast}`,
-                  transform: suggestionCollapsed ? 'rotate(0deg)' : 'rotate(90deg)',
-                }}>▶</span>
+      {/* ② 下节课回顾清单 — 拿着就能上课，常驻展示 */}
+      {parsed.reviewList && (
+        <SectionCard
+          icon="📋"
+          title={t('ai_helper_teaching_summary_section_review')}
+          accentColor={COLORS.hydroGreen}
+        >
+          <div
+            className="markdown-body"
+            dangerouslySetInnerHTML={{ __html: renderMarkdown(parsed.reviewList) }}
+          />
+          {parsed.p1 && (
+            <div style={{ marginTop: SPACING.md, paddingTop: SPACING.md, borderTop: `1px dashed ${COLORS.border}` }}>
+              <div style={{
+                fontSize: '12px', fontWeight: 600, color: COLORS.textSecondary,
+                marginBottom: SPACING.sm, letterSpacing: '0.02em',
+              }}>
+                👥 个体干预建议
               </div>
-
-              {/* Collapsible content */}
-              {!suggestionCollapsed && (
-                <>
-                  {summary.overallSuggestion ? (
-                    <div
-                      className="markdown-body"
-                      style={{ padding: `${SPACING.base} ${SPACING.lg}` }}
-                      dangerouslySetInnerHTML={{ __html: renderMarkdown(summary.overallSuggestion) }}
-                    />
-                  ) : (
-                    <SkeletonBlock lines={10} />
-                  )}
-
-                  {/* Feedback */}
-                  <div style={{
-                    display: 'flex', alignItems: 'center', justifyContent: 'flex-end',
-                    gap: SPACING.sm, padding: `${SPACING.sm} ${SPACING.base}`,
-                    borderTop: `1px solid ${COLORS.border}`,
-                  }}>
-                    {feedbackSubmitted ? (
-                      <span style={{ fontSize: '12px', color: COLORS.successText }}>
-                        {t('ai_helper_teaching_summary_feedback_thanks')}
-                      </span>
-                    ) : (
-                      <>
-                        {(['up', 'down'] as const).map(rating => (
-                          <button
-                            key={rating}
-                            onClick={() => handleFeedback(rating)}
-                            style={{
-                              fontSize: '12px', padding: '3px 8px',
-                              border: `1px solid ${COLORS.border}`,
-                              borderRadius: RADIUS.sm,
-                              backgroundColor: 'transparent',
-                              color: summary.feedback?.rating === rating
-                                ? (rating === 'up' ? COLORS.successText : COLORS.errorText)
-                                : COLORS.textMuted,
-                              cursor: 'pointer',
-                            }}
-                          >
-                            {rating === 'up' ? t('ai_helper_teaching_summary_feedback_helpful') : t('ai_helper_teaching_summary_feedback_not_helpful')}
-                          </button>
-                        ))}
-                      </>
-                    )}
-                  </div>
-                </>
-              )}
+              <div
+                className="markdown-body"
+                dangerouslySetInnerHTML={{ __html: renderMarkdown(parsed.p1) }}
+              />
             </div>
+          )}
+        </SectionCard>
+      )}
+
+      {/* ③ 学生问题 — 去重后的重点卡片 + 其他观察一行带过 */}
+      <SectionCard
+        icon="🔍"
+        title={`${t('ai_helper_teaching_summary_section_problems')}${primaryFindings.length > 0 ? `（${primaryFindings.length}）` : ''}`}
+        accentColor={highCount > 0 ? SEVERITY_COLORS.high.text : COLORS.border}
+      >
+        {primaryFindings.length === 0 ? (
+          <div style={{ color: COLORS.textMuted, fontSize: '13px', fontStyle: 'italic' }}>
+            {t('ai_helper_teaching_summary_no_findings')}
+          </div>
+        ) : (
+          primaryFindings.map(f => (
+            <FindingCard
+              key={f.id}
+              finding={f}
+              deepDiveText={summary.deepDiveResults?.[f.id]}
+              studentNames={summary.studentNames}
+            />
+          ))
+        )}
+
+        {secondaryFindings.length > 0 && (
+          <div style={{
+            marginTop: SPACING.sm,
+            padding: `${SPACING.sm} ${SPACING.md}`,
+            backgroundColor: COLORS.bgPage,
+            borderRadius: RADIUS.sm,
+            fontSize: '12px', color: COLORS.textMuted, lineHeight: 1.8,
+          }}>
+            <strong>{t('ai_helper_teaching_summary_other_observations')}：</strong>
+            {secondaryFindings.map(f => f.title).join(' · ')}
           </div>
         )}
-      </div>
+      </SectionCard>
+
+      {/* ④ 课后强化训练 — 一键复制下发 */}
+      {homeworkMd && (
+        <SectionCard
+          icon="📝"
+          title={t('ai_helper_teaching_summary_section_homework')}
+          accentColor={COLORS.primary}
+          headerRight={(
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: SPACING.sm }}>
+              {copyState !== 'idle' && (
+                <span style={{
+                  fontSize: '12px',
+                  color: copyState === 'copied' ? COLORS.successText : COLORS.errorText,
+                }}>
+                  {copyState === 'copied'
+                    ? t('ai_helper_teaching_summary_copied')
+                    : t('ai_helper_teaching_summary_copy_failed')}
+                </span>
+              )}
+              <button
+                onClick={handleCopyHomework}
+                style={{
+                  fontSize: '12px', padding: '3px 10px',
+                  border: `1px solid ${COLORS.primary}`,
+                  borderRadius: RADIUS.sm,
+                  backgroundColor: 'transparent',
+                  color: COLORS.primary,
+                  cursor: 'pointer',
+                }}
+              >
+                📄 {t('ai_helper_teaching_summary_copy_homework')}
+              </button>
+            </span>
+          )}
+        >
+          <div style={{
+            fontSize: '12px', color: COLORS.textMuted, marginBottom: SPACING.md,
+          }}>
+            {t('ai_helper_teaching_summary_homework_hint')}
+          </div>
+          <div
+            className="markdown-body"
+            dangerouslySetInnerHTML={{ __html: renderMarkdown(homeworkMd) }}
+          />
+        </SectionCard>
+      )}
+
+      {/* 兜底：解析失败（或旧版文档）时完整展示 AI 报告 */}
+      {!parsedOk && summary.overallSuggestion && (
+        <SectionCard
+          icon="🤖"
+          title={t('ai_helper_teaching_summary_overall_suggestion')}
+          accentColor={COLORS.hydroGreen}
+        >
+          <div
+            className="markdown-body"
+            dangerouslySetInnerHTML={{ __html: renderMarkdown(summary.overallSuggestion) }}
+          />
+        </SectionCard>
+      )}
+
+      {/* 已解析主要板块后剩余的未识别章节（如旧版 P0 长报告），默认折叠 */}
+      {parsedOk && parsed.rest.length > 0 && (
+        <div style={{
+          border: `1px solid ${COLORS.border}`,
+          borderRadius: RADIUS.md,
+          backgroundColor: COLORS.bgCard,
+          marginBottom: SPACING.lg,
+          overflow: 'hidden',
+        }}>
+          <div
+            onClick={() => setFullReportCollapsed(!fullReportCollapsed)}
+            style={{
+              padding: `${SPACING.md} ${SPACING.base}`,
+              cursor: 'pointer', userSelect: 'none',
+              display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+            }}
+          >
+            <span style={{
+              fontWeight: 600, fontSize: '13px', color: COLORS.textMuted,
+              letterSpacing: '0.05em',
+            }}>
+              🗂 {t('ai_helper_teaching_summary_section_full_report')}
+            </span>
+            <span style={{
+              display: 'inline-block', width: '16px', height: '16px',
+              textAlign: 'center', lineHeight: '16px', fontSize: '12px',
+              color: COLORS.textMuted,
+              transition: `transform ${TRANSITIONS.fast}`,
+              transform: fullReportCollapsed ? 'rotate(0deg)' : 'rotate(90deg)',
+            }}>▶</span>
+          </div>
+          {!fullReportCollapsed && (
+            <div
+              className="markdown-body"
+              style={{ padding: `0 ${SPACING.base} ${SPACING.base}`, borderTop: `1px solid ${COLORS.border}`, paddingTop: SPACING.md }}
+              dangerouslySetInnerHTML={{ __html: renderMarkdown(parsed.rest.join('\n\n')) }}
+            />
+          )}
+        </div>
+      )}
+
+      {/* 生成中兜底：completed 但建议为空 */}
+      {!summary.overallSuggestion && !homeworkMd && (
+        <SkeletonBlock lines={6} />
+      )}
+
+      {/* Feedback */}
+      {feedbackRow}
     </div>
   );
 };

--- a/frontend/teachingSummary/useTeachingSummary.ts
+++ b/frontend/teachingSummary/useTeachingSummary.ts
@@ -22,6 +22,12 @@ export interface TeachingFinding {
   aiSuggestion?: string;
   aiAnalysis?: string;
   confidence?: 'high' | 'low' | 'insufficient_data';
+  /** 错误签名（合并自错误聚类维度） */
+  errorSignature?: string;
+  /** 折叠进本发现的关联洞察，展开时展示 */
+  supplements?: string[];
+  /** 次要发现：不单独成卡片，在"其他观察"中一行带过 */
+  isSecondary?: boolean;
 }
 
 export interface TeachingSummary {
@@ -44,6 +50,10 @@ export interface TeachingSummary {
   };
   findings: TeachingFinding[];
   overallSuggestion: string;
+  /** 课后强化训练（挖空作业）markdown；旧文档无此字段（作业拼在 overallSuggestion 末尾） */
+  homeworkText?: string;
+  /** 发现项涉及的学生 uid -> 用户名 */
+  studentNames?: Record<string, string>;
   deepDiveResults: Record<string, string>;
   feedback?: { rating: 'up' | 'down'; comment?: string };
   tokenUsage: { promptTokens: number; completionTokens: number };

--- a/src/__tests__/models/teachingSummary.test.ts
+++ b/src/__tests__/models/teachingSummary.test.ts
@@ -288,12 +288,30 @@ describe('TeachingSummaryModel', () => {
             stats,
             findings: [sampleFinding],
             overallSuggestion: 'Focus on boundary conditions',
+            homeworkText: '',
+            studentNames: {},
             deepDiveResults: {},
             tokenUsage: { promptTokens: 1000, completionTokens: 500 },
             generationTimeMs: 3200,
           },
         },
       );
+    });
+
+    it('should save homeworkText and studentNames when provided', async () => {
+      await model.saveResults('summary1', {
+        stats: { totalStudents: 10, participatedStudents: 8, aiUserCount: 5, problemCount: 3 },
+        findings: [],
+        overallSuggestion: 'ok',
+        homeworkText: '### 📝 课后巩固作业\n第 1 题…',
+        studentNames: { '101': '张三' },
+        tokenUsage: { promptTokens: 200, completionTokens: 100 },
+        generationTimeMs: 800,
+      });
+
+      const call = col.updateOne.mock.calls[0];
+      expect(call[1].$set.homeworkText).toContain('课后巩固作业');
+      expect(call[1].$set.studentNames).toEqual({ '101': '张三' });
     });
 
     it('should save deepDiveResults when provided', async () => {

--- a/src/__tests__/services/analyzers/findingConsolidator.test.ts
+++ b/src/__tests__/services/analyzers/findingConsolidator.test.ts
@@ -1,0 +1,284 @@
+import {
+  consolidateFindings,
+  MAX_PRIMARY,
+} from '../../../services/analyzers/findingConsolidator';
+import { TeachingFinding } from '../../../models/teachingSummary';
+
+function makeFinding(overrides: Partial<TeachingFinding> = {}): TeachingFinding {
+  const students = overrides.evidence?.affectedStudents ?? [1, 2, 3, 4, 5];
+  return {
+    id: overrides.id ?? 'finding_test_1',
+    dimension: 'commonError',
+    severity: 'medium',
+    title: 'test finding',
+    needsDeepDive: false,
+    ...overrides,
+    evidence: {
+      affectedStudents: students,
+      affectedProblems: [101],
+      metrics: { affectedCount: students.length },
+      ...(overrides.evidence ?? {}),
+    },
+  };
+}
+
+const range = (n: number, start = 1) => Array.from({ length: n }, (_, i) => start + i);
+
+describe('consolidateFindings — errorCluster merge', () => {
+  it('merges an errorCluster into the commonError on the same problem with overlapping students', () => {
+    const common = makeFinding({
+      id: 'finding_commonError_1',
+      dimension: 'commonError',
+      title: '百鸡问题 (1138)：42% 学生遇到 WA 错误',
+      needsDeepDive: true,
+      evidence: {
+        affectedStudents: range(42),
+        affectedProblems: [1138],
+        metrics: { affectedCount: 42 },
+      },
+    });
+    const cluster = makeFinding({
+      id: 'finding_errorCluster_1',
+      dimension: 'errorCluster',
+      title: '百鸡问题：34% 学生遇到相同错误模式 (WA)',
+      errorSignature: 'WA:tests[3,4]',
+      needsDeepDive: true,
+      evidence: {
+        affectedStudents: range(34),
+        affectedProblems: [1138],
+        metrics: { affectedCount: 34 },
+        samples: { code: ['int main() {}'] },
+      },
+    });
+
+    const result = consolidateFindings([common, cluster]);
+
+    expect(result).toHaveLength(1);
+    const merged = result[0];
+    expect(merged.dimension).toBe('commonError');
+    expect(merged.errorSignature).toBe('WA:tests[3,4]');
+    expect(merged.evidence.samples?.code).toEqual(['int main() {}']);
+    expect(merged.evidence.metrics.sameSignatureCount).toBe(34);
+    expect(merged.supplements?.length).toBe(1);
+    expect(merged.supplements![0]).toContain('WA:tests[3,4]');
+  });
+
+  it('keeps an errorCluster standalone when there is no overlapping commonError on that problem', () => {
+    const common = makeFinding({
+      id: 'finding_commonError_1',
+      dimension: 'commonError',
+      evidence: {
+        affectedStudents: range(10),
+        affectedProblems: [200],
+        metrics: {},
+      },
+    });
+    const cluster = makeFinding({
+      id: 'finding_errorCluster_1',
+      dimension: 'errorCluster',
+      errorSignature: 'CE:syntax',
+      evidence: {
+        affectedStudents: range(10, 500),
+        affectedProblems: [300],
+        metrics: {},
+      },
+    });
+
+    const result = consolidateFindings([common, cluster]);
+    expect(result).toHaveLength(2);
+    expect(result.map(f => f.id)).toContain('finding_errorCluster_1');
+  });
+
+  it('prefers the commonError whose title mentions the cluster status label', () => {
+    const commonWA = makeFinding({
+      id: 'finding_commonError_wa',
+      dimension: 'commonError',
+      title: '题目 A：40% 学生遇到 WA 错误',
+      evidence: { affectedStudents: range(20), affectedProblems: [1], metrics: {} },
+    });
+    const commonTLE = makeFinding({
+      id: 'finding_commonError_tle',
+      dimension: 'commonError',
+      title: '题目 A：38% 学生遇到 TLE 错误',
+      evidence: { affectedStudents: range(19), affectedProblems: [1], metrics: {} },
+    });
+    const cluster = makeFinding({
+      id: 'finding_errorCluster_1',
+      dimension: 'errorCluster',
+      errorSignature: 'TLE:tests[7]',
+      evidence: { affectedStudents: range(18), affectedProblems: [1], metrics: {} },
+    });
+
+    const result = consolidateFindings([commonWA, commonTLE, cluster]);
+    const tle = result.find(f => f.id === 'finding_commonError_tle');
+    expect(result).toHaveLength(2);
+    expect(tle?.errorSignature).toBe('TLE:tests[7]');
+  });
+});
+
+describe('consolidateFindings — crossCorrelation folding', () => {
+  it('folds a crossCorrelation whose students are contained in a host finding', () => {
+    const atRisk = makeFinding({
+      id: 'finding_atRisk_1',
+      dimension: 'atRisk',
+      severity: 'high',
+      title: '7 名学生在 ≥70% 的题目上未通过（占比 7%）',
+      evidence: { affectedStudents: range(7), affectedProblems: [1, 2, 3], metrics: {} },
+    });
+    const cross = makeFinding({
+      id: 'finding_crossCorrelation_1',
+      dimension: 'crossCorrelation',
+      title: '7名高危学生行为分布: 2名未参与, 5名沉默挣扎',
+      confidence: 'low',
+      evidence: { affectedStudents: range(7), affectedProblems: [], metrics: {} },
+    });
+
+    const result = consolidateFindings([atRisk, cross]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('finding_atRisk_1');
+    expect(result[0].supplements).toContain('7名高危学生行为分布: 2名未参与, 5名沉默挣扎');
+  });
+
+  it('keeps a crossCorrelation standalone when no host covers its students', () => {
+    const atRisk = makeFinding({
+      id: 'finding_atRisk_1',
+      dimension: 'atRisk',
+      evidence: { affectedStudents: range(7), affectedProblems: [1], metrics: {} },
+    });
+    const cross = makeFinding({
+      id: 'finding_crossCorrelation_1',
+      dimension: 'crossCorrelation',
+      evidence: { affectedStudents: range(20, 100), affectedProblems: [1], metrics: {} },
+    });
+
+    const result = consolidateFindings([atRisk, cross]);
+    expect(result.map(f => f.id)).toContain('finding_crossCorrelation_1');
+  });
+});
+
+describe('consolidateFindings — ranking and capping', () => {
+  it('sorts by severity then affected count and marks overflow as secondary', () => {
+    const findings = [
+      makeFinding({
+        id: 'low_small', severity: 'low',
+        evidence: { affectedStudents: range(5), affectedProblems: [1], metrics: {} },
+      }),
+      makeFinding({
+        id: 'high_big', severity: 'high', dimension: 'atRisk',
+        evidence: { affectedStudents: range(40), affectedProblems: [2], metrics: {} },
+      }),
+      makeFinding({
+        id: 'medium_1', severity: 'medium', dimension: 'temporalPattern',
+        evidence: { affectedStudents: range(10), affectedProblems: [3], metrics: {} },
+      }),
+      makeFinding({
+        id: 'medium_2', severity: 'medium', dimension: 'strategy',
+        evidence: { affectedStudents: range(20), affectedProblems: [4], metrics: {} },
+      }),
+      makeFinding({
+        id: 'high_small', severity: 'high', dimension: 'difficulty',
+        evidence: { affectedStudents: range(8), affectedProblems: [5], metrics: {} },
+      }),
+      makeFinding({
+        id: 'low_tail', severity: 'low', dimension: 'aiEffectiveness',
+        evidence: { affectedStudents: range(4), affectedProblems: [6], metrics: {} },
+      }),
+    ];
+
+    const result = consolidateFindings(findings);
+
+    expect(result.map(f => f.id)).toEqual([
+      'high_big', 'high_small', 'medium_2', 'medium_1', 'low_small', 'low_tail',
+    ]);
+    const secondary = result.filter(f => f.isSecondary).map(f => f.id);
+    expect(secondary).toEqual(['low_tail']);
+    expect(result.filter(f => !f.isSecondary)).toHaveLength(MAX_PRIMARY);
+  });
+
+  it('pins progress findings last without consuming a primary slot', () => {
+    const findings = [
+      makeFinding({
+        id: 'progress_1', dimension: 'progress', severity: 'low',
+        evidence: { affectedStudents: range(64), affectedProblems: [1], metrics: {} },
+      }),
+      makeFinding({
+        id: 'error_1', severity: 'high',
+        evidence: { affectedStudents: range(42), affectedProblems: [1], metrics: {} },
+      }),
+    ];
+
+    const result = consolidateFindings(findings);
+    expect(result.map(f => f.id)).toEqual(['error_1', 'progress_1']);
+    expect(result.find(f => f.id === 'progress_1')?.isSecondary).toBeUndefined();
+  });
+
+  it('handles the screenshot scenario: 8 findings collapse to a focused set', () => {
+    // 重现用户截图：百鸡问题/再次换钞票各有 commonError+errorCluster,
+    // atRisk + 行为分布 crossCorrelation, temporalPattern, progress
+    const students1138 = range(42);
+    const students1139 = range(35, 200);
+    const atRiskUids = range(7, 400);
+
+    const findings = [
+      makeFinding({
+        id: 'cross_atrisk', dimension: 'crossCorrelation', severity: 'high',
+        title: '7名高危学生行为分布: 2名未参与',
+        confidence: 'low',
+        evidence: { affectedStudents: atRiskUids, affectedProblems: [], metrics: {} },
+      }),
+      makeFinding({
+        id: 'common_1138', dimension: 'commonError', severity: 'medium',
+        title: '百鸡问题 (1138)：42% 学生遇到 WA 错误',
+        evidence: { affectedStudents: students1138, affectedProblems: [1138], metrics: {} },
+      }),
+      makeFinding({
+        id: 'common_1139', dimension: 'commonError', severity: 'medium',
+        title: '再次换钞票 (1139)：35% 学生遇到 WA 错误',
+        evidence: { affectedStudents: students1139, affectedProblems: [1139], metrics: {} },
+      }),
+      makeFinding({
+        id: 'atrisk', dimension: 'atRisk', severity: 'medium',
+        title: '7 名学生在 ≥70% 的题目上未通过（占比 7%）',
+        evidence: { affectedStudents: atRiskUids, affectedProblems: [1138, 1139, 1140], metrics: {} },
+      }),
+      makeFinding({
+        id: 'cluster_1138', dimension: 'errorCluster', severity: 'medium',
+        title: '百鸡问题：42% 学生遇到相同错误模式 (WA)',
+        errorSignature: 'WA:tests[1,2]',
+        evidence: { affectedStudents: students1138, affectedProblems: [1138], metrics: {} },
+      }),
+      makeFinding({
+        id: 'cluster_1139', dimension: 'errorCluster', severity: 'medium',
+        title: '再次换钞票：34% 学生遇到相同错误模式 (WA)',
+        errorSignature: 'WA:tests[5]',
+        evidence: { affectedStudents: students1139.slice(0, 34), affectedProblems: [1139], metrics: {} },
+      }),
+      makeFinding({
+        id: 'temporal', dimension: 'temporalPattern', severity: 'medium',
+        title: '10 名学生呈现"未充分参与"行为模式（10%）',
+        confidence: 'low',
+        evidence: { affectedStudents: range(10, 600), affectedProblems: [1138, 1139, 1140], metrics: {} },
+      }),
+      makeFinding({
+        id: 'progress', dimension: 'progress', severity: 'low',
+        title: '64 名学生完成了全部 3 道题目（63%）',
+        evidence: { affectedStudents: range(64, 700), affectedProblems: [1138, 1139, 1140], metrics: {} },
+      }),
+    ];
+
+    const result = consolidateFindings(findings);
+
+    // 8 条 → 5 条：两组 commonError+errorCluster 各合并为一条,
+    // crossCorrelation 折叠进 atRisk, progress 保留在末尾
+    expect(result).toHaveLength(5);
+    expect(result.filter(f => f.isSecondary)).toHaveLength(0);
+    expect(result[result.length - 1].dimension).toBe('progress');
+
+    const atRisk = result.find(f => f.id === 'atrisk');
+    expect(atRisk?.supplements).toContain('7名高危学生行为分布: 2名未参与');
+
+    const merged1138 = result.find(f => f.id === 'common_1138');
+    expect(merged1138?.errorSignature).toBe('WA:tests[1,2]');
+  });
+});

--- a/src/__tests__/services/teachingSuggestionService.test.ts
+++ b/src/__tests__/services/teachingSuggestionService.test.ts
@@ -127,7 +127,6 @@ describe('buildMainPrompt', () => {
     const { system } = buildMainPrompt(input);
     expect(system).toContain('坏例子');
     expect(system).toContain('好例子');
-    expect(system).toContain('问题发现报告');
   });
 
   it('should include edge case handling in system prompt', () => {
@@ -137,14 +136,50 @@ describe('buildMainPrompt', () => {
     expect(system).toContain('AI 使用数据为 0');
   });
 
-  it('should include P0/P1 framework with problem discovery format', () => {
+  it('should include P0/P1 framework and behavior pattern labels', () => {
     const input = makeInput();
     const { system } = buildMainPrompt(input);
     expect(system).toContain('错误模式');
-    expect(system).toContain('数据全景');
-    expect(system).toContain('根因定位');
     expect(system).toContain('持续努力型');
     expect(system).toContain('受挫放弃型');
+  });
+
+  it('should not request the removed p0_action_plan section (deduplicated vs finding cards)', () => {
+    const input = makeInput();
+    const { user, system } = buildMainPrompt(input);
+    expect(user).not.toContain('p0_action_plan');
+    expect(system).not.toContain('p0_action_plan');
+    expect(system).not.toContain('数据全景');
+  });
+
+  it('should send primary findings as JSON and secondary findings as one-line titles', () => {
+    const input = makeInput({
+      findings: [
+        makeFinding(),
+        makeFinding({
+          id: 'f2',
+          title: '次要发现示例',
+          isSecondary: true,
+          evidence: {
+            affectedStudents: [4, 5],
+            affectedProblems: [102],
+            metrics: {},
+          },
+        }),
+      ],
+    });
+    const { user } = buildMainPrompt(input);
+    expect(user).toContain('数组越界错误');
+    expect(user).toContain('## 其他观察');
+    expect(user).toContain('- 次要发现示例');
+    // secondary finding must not be serialized as JSON
+    expect(user).not.toContain('"title": "次要发现示例"');
+  });
+
+  it('should omit the secondary section when all findings are primary', () => {
+    const input = makeInput();
+    const { user } = buildMainPrompt(input);
+    expect(user).not.toContain('## 其他观察');
   });
 
   it('should format user prompt with problem contexts', () => {

--- a/src/handlers/teachingSummaryHandler.ts
+++ b/src/handlers/teachingSummaryHandler.ts
@@ -159,6 +159,32 @@ export class TeachingSummaryHandler extends Handler {
     }
   }
 
+  /**
+   * 解析发现项涉及的学生 uid → 用户名映射（best-effort，失败不阻塞生成）
+   */
+  private async resolveStudentNames(
+    findings: Array<{ evidence: { affectedStudents: number[] } }>,
+  ): Promise<Record<string, string>> {
+    const names: Record<string, string> = {};
+    try {
+      const uids = new Set<number>();
+      for (const f of findings) {
+        for (const uid of f.evidence.affectedStudents) uids.add(uid);
+      }
+      if (uids.size === 0) return names;
+
+      const userDocs = await this.ctx.db.collection('user')
+        .find({ _id: { $in: Array.from(uids) } }, { projection: { _id: 1, uname: 1 } })
+        .toArray();
+      for (const u of userDocs) {
+        names[String(u._id)] = (u as any).uname || `User #${u._id}`;
+      }
+    } catch (err) {
+      console.error('[TeachingSummaryHandler] resolveStudentNames failed:', err);
+    }
+    return names;
+  }
+
   private async generateAsync(
     model: TeachingSummaryModel,
     domainId: string,
@@ -257,7 +283,7 @@ export class TeachingSummaryHandler extends Handler {
             ))
             .map(f => ({
               title: f.title,
-              errorSignature: (f.evidence.metrics as any).errorSignature as string | undefined,
+              errorSignature: f.errorSignature,
               affectedCount: f.evidence.affectedStudents.length,
             }))
         : [];
@@ -280,20 +306,17 @@ export class TeachingSummaryHandler extends Handler {
           : Promise.resolve(null),
       ]);
 
-      const combinedSuggestion = fillInResult
-        ? `${overallResult.text}\n\n${fillInResult.text}`
-        : overallResult.text;
-
       let totalPromptTokens = overallResult.tokenUsage.promptTokens
         + (fillInResult?.tokenUsage.promptTokens ?? 0);
       let totalCompletionTokens = overallResult.tokenUsage.completionTokens
         + (fillInResult?.tokenUsage.completionTokens ?? 0);
 
-      // Deep dives for findings that need them
+      // Deep dives only for primary findings — secondary ones are shown as
+      // one-liners in the UI and don't warrant an extra LLM call each
       const deepDiveResults: Record<string, string> = {};
       const problemDocMap = new Map(problemDocs.map((doc: any) => [doc.docId as number, doc]));
 
-      const deepDiveFindings = analysisResult.findings.filter(f => f.needsDeepDive);
+      const deepDiveFindings = analysisResult.findings.filter(f => f.needsDeepDive && !f.isSecondary);
 
       // Batch-fetch code samples for all deep-dive findings (avoids N+1 queries)
       if (deepDiveFindings.length > 0) {
@@ -353,12 +376,19 @@ export class TeachingSummaryHandler extends Handler {
         totalCompletionTokens += deepDiveResult.tokenUsage.completionTokens;
       }
 
-      // Save completed results
+      // Resolve student names referenced by findings so the UI can show
+      // actionable name lists instead of opaque uid counts
+      const studentNames = await this.resolveStudentNames(analysisResult.findings);
+
+      // Save completed results — homework is stored separately from the main
+      // suggestion so the UI can surface it as a first-class deliverable
       await model.updateProgress(summaryId, 'saving');
       await model.saveResults(summaryId, {
         stats: analysisResult.stats,
         findings: analysisResult.findings,
-        overallSuggestion: combinedSuggestion,
+        overallSuggestion: overallResult.text,
+        homeworkText: fillInResult?.text ?? '',
+        studentNames,
         deepDiveResults,
         tokenUsage: { promptTokens: totalPromptTokens, completionTokens: totalCompletionTokens },
         generationTimeMs: Date.now() - startTime,

--- a/src/models/teachingSummary.ts
+++ b/src/models/teachingSummary.ts
@@ -72,6 +72,12 @@ export interface TeachingFinding {
   aiAnalysis?: string;
   confidence?: ConfidenceLevel;
   fillInExercise?: FillInExercise;
+  /** 错误签名（来自 errorCluster 维度，合并后随主发现保留） */
+  errorSignature?: string;
+  /** 被折叠进本发现的关联洞察（如交叉关联、错误聚类的补充信息），展开时展示 */
+  supplements?: string[];
+  /** 次要发现：不单独成卡片，前端在"其他观察"中一行带过 */
+  isSecondary?: boolean;
 }
 
 
@@ -95,6 +101,10 @@ export interface TeachingSummary {
   };
   findings: TeachingFinding[];
   overallSuggestion: string;
+  /** 课后强化训练（挖空作业）markdown，独立于 overallSuggestion 存储；旧文档无此字段（作业拼在 overallSuggestion 末尾） */
+  homeworkText?: string;
+  /** 发现项涉及的学生 uid -> 用户名 映射，供前端展示名单 */
+  studentNames?: Record<string, string>;
   deepDiveResults: Record<string, string>;
   feedback?: { rating: 'up' | 'down'; comment?: string };
   tokenUsage: { promptTokens: number; completionTokens: number };
@@ -257,6 +267,8 @@ export class TeachingSummaryModel {
       stats: TeachingSummary['stats'];
       findings: TeachingFinding[];
       overallSuggestion: string;
+      homeworkText?: string;
+      studentNames?: Record<string, string>;
       deepDiveResults?: Record<string, string>;
       tokenUsage: TeachingSummary['tokenUsage'];
       generationTimeMs: number;
@@ -271,6 +283,8 @@ export class TeachingSummaryModel {
           stats: data.stats,
           findings: data.findings,
           overallSuggestion: data.overallSuggestion,
+          homeworkText: data.homeworkText ?? '',
+          studentNames: data.studentNames ?? {},
           deepDiveResults: data.deepDiveResults ?? {},
           tokenUsage: data.tokenUsage,
           generationTimeMs: data.generationTimeMs,

--- a/src/services/analyzers/errorClusterAnalyzer.ts
+++ b/src/services/analyzers/errorClusterAnalyzer.ts
@@ -101,6 +101,7 @@ export function analyzeErrorClusters(
         dimension: 'errorCluster',
         severity: uids.size >= totalStudents * 0.5 ? 'high' : 'medium',
         title: `${pidTitles?.get(pid) || `题目 ${pid}`}：${pct}% 学生遇到相同错误模式 (${statusLabel})`,
+        errorSignature: sig,
         evidence: {
           affectedStudents: Array.from(uids),
           affectedProblems: [pid],

--- a/src/services/analyzers/findingConsolidator.ts
+++ b/src/services/analyzers/findingConsolidator.ts
@@ -1,0 +1,189 @@
+/**
+ * Finding Consolidator — 发现项整合器
+ *
+ * 规则引擎的 11 个维度常对同一现象从不同角度各出一条发现，教师会看到大量重复内容：
+ * commonError 与 errorCluster 对同一题目各出一条、crossCorrelation 把 atRisk 的
+ * 学生集合重新切一遍再出一条。本模块在 LLM 调用与前端展示之前做三件事：
+ *
+ * 1. 合并：同题且学生集合高度重叠的 errorCluster 并入 commonError，
+ *    错误签名与代码样本随主发现保留；
+ * 2. 折叠：学生集合基本被某个主发现覆盖的 crossCorrelation 降级为该发现的
+ *    supplements 补充说明，不再单独成条；
+ * 3. 排序限量：按严重度 + 影响人数排序，前 MAX_PRIMARY 条为重点问题，
+ *    其余标记 isSecondary（前端在"其他观察"中一行带过）。
+ *    progress（正向进展）不参与排序限量，固定排在最后由前端另行展示。
+ */
+
+import { TeachingFinding } from '../../models/teachingSummary';
+
+export const MAX_PRIMARY = 5;
+
+/** errorCluster 并入 commonError 所需的最小学生重叠率（占较小集合的比例） */
+const MERGE_OVERLAP_THRESHOLD = 0.5;
+
+/** crossCorrelation 折叠为补充说明所需的最小学生包含率 */
+const FOLD_CONTAINMENT_THRESHOLD = 0.8;
+
+const SEVERITY_RANK: Record<TeachingFinding['severity'], number> = {
+  high: 2,
+  medium: 1,
+  low: 0,
+};
+
+function overlapRatio(a: number[], b: number[]): number {
+  if (a.length === 0 || b.length === 0) return 0;
+  const setB = new Set(b);
+  let shared = 0;
+  for (const uid of a) {
+    if (setB.has(uid)) shared++;
+  }
+  return shared / Math.min(a.length, b.length);
+}
+
+/** |a ∩ b| / |a| — a 被 b 覆盖的比例 */
+function containmentRatio(a: number[], b: number[]): number {
+  if (a.length === 0) return 0;
+  const setB = new Set(b);
+  let shared = 0;
+  for (const uid of a) {
+    if (setB.has(uid)) shared++;
+  }
+  return shared / a.length;
+}
+
+function maxSeverity(
+  a: TeachingFinding['severity'],
+  b: TeachingFinding['severity'],
+): TeachingFinding['severity'] {
+  return SEVERITY_RANK[a] >= SEVERITY_RANK[b] ? a : b;
+}
+
+/** 从错误签名提取状态标签（如 "WA:tests[3,4]" → "WA"） */
+function signatureStatusLabel(signature?: string): string | null {
+  if (!signature) return null;
+  const idx = signature.indexOf(':');
+  return idx > 0 ? signature.slice(0, idx) : signature;
+}
+
+function pushSupplement(host: TeachingFinding, text: string): void {
+  if (!host.supplements) host.supplements = [];
+  if (!host.supplements.includes(text)) host.supplements.push(text);
+}
+
+/**
+ * Step 1: 将 errorCluster 并入同题、学生高度重叠的 commonError。
+ * 优先选择标题含有相同错误状态标签（WA/TLE/...）的宿主。
+ */
+function mergeErrorClusters(findings: TeachingFinding[]): TeachingFinding[] {
+  const commonErrors = findings.filter(f => f.dimension === 'commonError');
+  const dropped = new Set<string>();
+
+  for (const cluster of findings) {
+    if (cluster.dimension !== 'errorCluster') continue;
+    const pid = cluster.evidence.affectedProblems[0];
+    if (pid === undefined) continue;
+
+    const candidates = commonErrors
+      .filter(host =>
+        host.evidence.affectedProblems.length === 1
+        && host.evidence.affectedProblems[0] === pid)
+      .map(host => ({
+        host,
+        overlap: overlapRatio(cluster.evidence.affectedStudents, host.evidence.affectedStudents),
+      }))
+      .filter(({ overlap }) => overlap >= MERGE_OVERLAP_THRESHOLD);
+
+    if (candidates.length === 0) continue;
+
+    // 同状态标签的宿主优先，其次按重叠率
+    const statusLabel = signatureStatusLabel(cluster.errorSignature);
+    candidates.sort((a, b) => {
+      if (statusLabel) {
+        const aMatch = a.host.title.includes(statusLabel) ? 1 : 0;
+        const bMatch = b.host.title.includes(statusLabel) ? 1 : 0;
+        if (aMatch !== bMatch) return bMatch - aMatch;
+      }
+      return b.overlap - a.overlap;
+    });
+
+    const host = candidates[0].host;
+    host.severity = maxSeverity(host.severity, cluster.severity);
+    host.needsDeepDive = host.needsDeepDive || cluster.needsDeepDive;
+    if (!host.errorSignature) host.errorSignature = cluster.errorSignature;
+    if (!host.evidence.samples?.code?.length && cluster.evidence.samples?.code?.length) {
+      host.evidence.samples = cluster.evidence.samples;
+    }
+    const clusterSize = cluster.evidence.affectedStudents.length;
+    host.evidence.metrics.sameSignatureCount = clusterSize;
+    pushSupplement(host,
+      `${clusterSize} 名学生的最后一次提交失败在同一处（错误签名 ${cluster.errorSignature || '相同错误模式'}），大概率是同一个知识点没讲透`);
+    dropped.add(cluster.id);
+  }
+
+  return findings.filter(f => !dropped.has(f.id));
+}
+
+/**
+ * Step 2: 学生集合基本被某主发现覆盖的 crossCorrelation 折叠为其补充说明。
+ */
+function foldCrossCorrelations(findings: TeachingFinding[]): TeachingFinding[] {
+  const hosts = findings.filter(
+    f => f.dimension !== 'crossCorrelation' && f.dimension !== 'progress',
+  );
+  const dropped = new Set<string>();
+
+  for (const cross of findings) {
+    if (cross.dimension !== 'crossCorrelation') continue;
+    if (cross.evidence.affectedStudents.length === 0) continue;
+
+    let best: TeachingFinding | null = null;
+    let bestContainment = 0;
+    for (const host of hosts) {
+      const containment = containmentRatio(
+        cross.evidence.affectedStudents,
+        host.evidence.affectedStudents,
+      );
+      if (containment > bestContainment) {
+        bestContainment = containment;
+        best = host;
+      }
+    }
+
+    if (best && bestContainment >= FOLD_CONTAINMENT_THRESHOLD) {
+      pushSupplement(best, cross.title);
+      dropped.add(cross.id);
+    }
+  }
+
+  return findings.filter(f => !dropped.has(f.id));
+}
+
+/**
+ * Step 3: 排序限量。progress 固定最后且不占重点名额。
+ */
+function rankAndCap(findings: TeachingFinding[]): TeachingFinding[] {
+  const progress = findings.filter(f => f.dimension === 'progress');
+  const rest = findings.filter(f => f.dimension !== 'progress');
+
+  rest.sort((a, b) => {
+    const sev = SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity];
+    if (sev !== 0) return sev;
+    return b.evidence.affectedStudents.length - a.evidence.affectedStudents.length;
+  });
+
+  rest.forEach((f, idx) => {
+    if (idx >= MAX_PRIMARY) f.isSecondary = true;
+  });
+
+  return [...rest, ...progress];
+}
+
+/**
+ * 主入口：合并 → 折叠 → 排序限量。
+ * 就地修改传入的 finding 对象（宿主吸收补充信息），返回整合后的新数组。
+ */
+export function consolidateFindings(findings: TeachingFinding[]): TeachingFinding[] {
+  const merged = mergeErrorClusters(findings);
+  const folded = foldCrossCorrelations(merged);
+  return rankAndCap(folded);
+}

--- a/src/services/teachingAnalysisService.ts
+++ b/src/services/teachingAnalysisService.ts
@@ -10,6 +10,7 @@ import { TeachingFinding, FindingDimension } from '../models/teachingSummary';
 import { analyzeErrorClusters } from './analyzers/errorClusterAnalyzer';
 import { analyzeTemporalPatterns } from './analyzers/temporalPatternAnalyzer';
 import { analyzeCorrelations } from './analyzers/correlationAnalyzer';
+import { consolidateFindings } from './analyzers/findingConsolidator';
 import { getClassSizeStrategy } from './analyzers/classSizeStrategy';
 import {
   shouldGenerateFillIn,
@@ -230,10 +231,12 @@ export class TeachingAnalysisService {
       findings.push(f);
     }
 
-    // Filter out findings from disabled dimensions
-    const filteredFindings = findings.filter(
+    // Filter out findings from disabled dimensions, then consolidate:
+    // merge duplicate error findings, fold cross-correlations into hosts,
+    // rank by severity/impact and mark overflow as secondary
+    const filteredFindings = consolidateFindings(findings.filter(
       f => !strategy.disabledDimensions.includes(f.dimension),
-    );
+    ));
 
     // Fill-in exercise candidates
     const fillInCandidates: FillInExercise[] = [];
@@ -264,6 +267,16 @@ export class TeachingAnalysisService {
         avgSubmissionCount: totalSubs / attempted,
       });
       if (trigger) fillInPids.push(pid);
+    }
+
+    // 保底：只要存在共性错误，至少为影响面最大的那道题生成课后强化训练，
+    // 避免教师在明明有共性问题时却拿不到任何作业素材
+    if (fillInPids.length === 0 && errorFindings.length > 0) {
+      const top = [...errorFindings].sort(
+        (a, b) => b.evidence.affectedStudents.length - a.evidence.affectedStudents.length,
+      )[0];
+      const topPid = top.evidence.affectedProblems[0];
+      if (topPid !== undefined) fillInPids.push(topPid);
     }
 
     if (fillInPids.length > 0) {

--- a/src/services/teachingSuggestionService.ts
+++ b/src/services/teachingSuggestionService.ts
@@ -8,19 +8,18 @@ import { TeachingFinding } from '../models/teachingSummary';
 
 // ─── 提示词模板 ──────────────────────────────────────────
 
-const MAIN_SYSTEM_PROMPT = `你是一位教龄15年的编程课教师，同时负责教学教研。你将根据规则引擎提供的【带有具体错误诊断和题目信息的】课堂分析数据，为授课教师生成清晰直观的问题发现报告和教学参考素材。报告的核心是回答两个问题：这节课学生的主要问题是什么、下节课开头几分钟该回顾什么。
+const MAIN_SYSTEM_PROMPT = `你是一位教龄15年的编程课教师，同时负责教学教研。你将根据规则引擎提供的【带有具体错误诊断和题目信息的】课堂分析数据，为授课教师提炼一份【一分钟能读完、拿着就能上课】的教学参考。核心回答两个问题：这节课学生的主要问题是什么、下节课开头几分钟该怎么讲。
 
 【核心约束】
-- 聚焦主要问题：P0 发现最多展开 3 个（按影响人数从高到低），其余发现在 p0_action_plan 章节末尾以"**其他观察**："开头用一行列表带过，不展开
-- 每条发现必须清晰呈现"错误是什么/影响多大/根因在哪"，用数据和具体例子说话
-- P0 发现必须锚定在数据中的具体题目、具体错误模式上
-- P1 建议必须锚定具体行为证据（提交次数、AI提问记录等），如有关联题目则引用，不得强行编造错误模式
-- 当某章节主要依据 "low" confidence 数据时，在该章节标题下方加注一次"⚠️ 数据有限，以下建议仅供参考"
-- 当数据标注为 "insufficient_data" 时，跳过该维度不做建议
+- 少而准：除表格外全文不超过 200 字。原始数据的逐条展示由系统界面完成，你只负责结论与课堂动作，不要复述数据清单
+- 聚焦影响人数最多的 1-3 个问题，其余一概不提
+- 每条结论必须锚定数据中的具体题目、具体错误模式，并引用影响人数/比例
+- 建议必须具体到照着就能做；严禁输出"加强练习"/"进行个别辅导"/"注意边界条件"这类空话
+- 当某条主要依据 "low" confidence 数据时，行末加注"（⚠️ 数据有限，仅供参考）"；标注为 "insufficient_data" 的数据直接跳过
 - 必须基于给定数据说话，严禁捏造数据或比例
 
 【优先级框架】
-P0 — 全局知识缺陷：>20%学生犯同一类错误（有具体错误签名和测试点信息）
+P0 — 全局知识缺陷：>20%学生犯同一类错误（有具体错误签名和测试点信息）→ 优先进入回顾清单
 P1 — 个体干预：按行为模式分类（持续努力型 / 受挫放弃型 / 沉默挣扎型 / 未参与型）
 
 【可推荐的教学干预方法】
@@ -40,12 +39,12 @@ P1 — 个体干预：按行为模式分类（持续努力型 / 受挫放弃型 
 【边缘情况处理】
 | 条件 | 行动 |
 |---|---|
-| 全班 AC 率 > 90% 且无 commonError | 在 p0_action_plan 章节输出"全班表现优秀"并列出可进一步挑战的方向：时空复杂度优化、进阶变式题等；next_class_review 清单改为 1-2 个值得全班表扬的共性亮点 + 1 个进阶挑战 |
+| 全班 AC 率 > 90% 且无 commonError | diagnosis 输出"全班表现优秀"及依据；next_class_review 清单改为 1-2 个值得全班表扬的共性亮点 + 1 个进阶挑战方向（时空复杂度优化、进阶变式题等） |
 | AI 使用数据为 0（全班未使用 AI） | 聚焦于提交记录分析，不做 AI 有效性对比 |
 
 【质量示例】
 - 坏例子（禁止）："加强对边界条件的练习" / "进行个别辅导" / "注意数组越界问题" / "建议教师在课上演示正确写法"
-- 好例子（要求）："35%的学生（10人）在T2中将循环条件写成 i<=n 而非 i<n，导致testcase #3 (n=0) 时数组越界。根因：未区分'元素个数'与'最大下标'的概念差异" / "错误集中在边界条件判断，错误签名 off_by_one，影响题目 P101、P103"
+- 好例子（要求）："35%的学生（10人）在T2把循环条件写成 i<=n 而非 i<n（错误模式 off_by_one）：给出 n=0 让全班口算循环会执行几次，再对比 i<n，暴露'元素个数'与'最大下标'的概念差异"
 
 【输出章节定义】
 你的报告可能包含以下章节。每次请求的 user prompt 末尾会给出 output_sections 列表，只输出该列表中指定的章节，未指定的章节不得出现在输出中。
@@ -61,32 +60,8 @@ P1 — 个体干预：按行为模式分类（持续努力型 / 受挫放弃型 
 |---|---|---|
 | 1 | {问题一句话，含影响面数据} | {如：给出 n=0 让全班口算 i<=n 的循环会执行几次，再对比 i<n} |
 
-■ p0_action_plan — P0全局错误发现报告
-### 🚨 问题发现报告
-（按影响人数从高到低排列，最多展开 3 个 P0 问题，每个独立一节；其余发现在本章节末尾以"**其他观察**："一行带过）
-
-#### [P0] {问题名称} — 影响 {N}人/{百分比}
-
-**📌 错误模式**：{一句话概括错误模式，引用错误签名}
-
-**🔍 具体表现**：
-- 错误签名：\`{errorSignature}\`，出现在测试点 {testcaseIds}
-- 典型错误代码：\`{学生代码中的关键错误行}\`
-- 学生常见误解："{学生认为的逻辑}" → 实际应为："{正确逻辑}"
-
-**📊 数据全景**：
-| 维度 | 数据 |
-|---|---|
-| 受影响学生数 | {N}人（占参与人数{百分比}） |
-| 涉及题目 | {pid列表} |
-| 错误集中度 | {该错误是分散在多题还是集中在某题} |
-
-**🧠 根因定位**：{用1-2句话说明知识盲点或认知误区，不要给出教学行动指令}
-
-**💡 可选干预方向**：{从【可推荐的教学干预方法】中选择1-2个适合的方法名称，仅列出方法名，不展开具体步骤}
-
-■ p1_behavior_intervention — P1个体干预建议
-#### [P1] 个体干预建议
+■ p1_behavior_intervention — 个体干预建议
+### 👥 个体干预建议
 （仅输出 count > 0 的行为模式，跳过人数为 0 或数据缺失的类别）
 | 行为模式 | 人数 | 建议动作 |
 |---|---|---|
@@ -238,7 +213,16 @@ export function buildMainPrompt(input: MainPromptInput): PromptMessages {
       ].filter(Boolean).join('\n')
     : '教学目标未提供';
 
-  const strippedFindings = stripSamples(findings);
+  // 重点发现给完整 JSON；次要发现只给标题一行，避免 LLM 把注意力分散到长尾
+  const primaryFindings = findings.filter(f => !f.isSecondary);
+  const secondaryFindings = findings.filter(f => f.isSecondary);
+  const strippedFindings = stripSamples(primaryFindings);
+
+  const secondarySection = secondaryFindings.length
+    ? `\n\n## 其他观察（次要发现，不要为其单独产出建议）\n${secondaryFindings
+        .map(f => `- ${f.title}`)
+        .join('\n')}`
+    : '';
 
   const problemSection = input.problemContexts?.length
     ? `\n## 题目内容\n${input.problemContexts
@@ -261,7 +245,7 @@ export function buildMainPrompt(input: MainPromptInput): PromptMessages {
       }, null, 2)}`
     : '';
 
-  const outputSections: string[] = ['diagnosis', 'next_class_review', 'p0_action_plan'];
+  const outputSections: string[] = ['diagnosis', 'next_class_review'];
   if (hasBehavior) outputSections.push('p1_behavior_intervention');
 
   const userPrompt = `## 教学上下文
@@ -275,8 +259,8 @@ ${contextSection}
 - 题目数量：${stats.problemCount}
 ${problemSection}
 
-## 规则引擎发现（JSON）
-${JSON.stringify(strippedFindings, null, 2)}${behaviorSection}
+## 规则引擎重点发现（JSON）
+${JSON.stringify(strippedFindings, null, 2)}${secondarySection}${behaviorSection}
 
 ---
 output_sections: ${JSON.stringify(outputSections)}


### PR DESCRIPTION
## What

针对教师反馈("发现项重复、报告太长抓不住重点、部分卡片展开为空")简化教学分析功能:

- **新增 `findingConsolidator`**:同题目、学生高度重叠的"错误聚类"并入"共性错误"(错误签名/代码样本作为补充保留);学生集合被主发现覆盖的"交叉关联"折叠为其展开后的补充说明;按严重度+影响人数排序,最多 5 条重点问题,其余在"其他观察"一行带过
- **主 LLM 报告砍掉 P0 长报告章节**(与发现卡片、深度诊断重复),只输出 一句话诊断 + 下节课回顾清单 + 个体干预建议;次要发现只以标题传入提示词
- **深度诊断只对重点发现执行**,减少 LLM 调用
- **挖空作业独立存储**(`homeworkText`),UI 作为"课后强化训练"板块支持一键复制下发;保底逻辑:只要存在共性错误,至少为影响面最大的题目生成作业
- **发现项附带学生名单**(`studentNames`,uid→用户名),展开卡片可见具体涉及哪些学生
- **前端按备课工作流重排**:📊 一句话诊断(置顶)→ 📋 下节课回顾清单(常驻)→ 🔍 学生问题(重点卡片+其他观察)→ 📝 课后强化训练(一键复制);无实际内容的卡片不再显示展开箭头;与标题重复的原始指标不再渲染

## Why

教学分析的目的是让教师根据课堂数据快速拿到下节课教学建议、看清学生问题、获得一份可下发的课后强化训练。此前 11 个分析维度对同一现象各出一条(截图场景 8 条发现实际只有约 4 个独立信息),AI 综合建议又把同样的问题复述一遍,教师难以抓住重点;"行为模式"等发现展开后只有与标题重复的裸指标,显得功能是空架子。

## How

- 整合逻辑放在规则引擎出口(`teachingAnalysisService.analyze()` 末尾),LLM 与前端拿到的都是去重后的发现,提示词 token 同步下降
- `errorCluster` 新增 `errorSignature` 字段,合并后随宿主发现保留,同时修复了 handler 中从 `metrics.errorSignature` 读取签名的死路径
- `overallSuggestion` 不再拼接作业文本;前端按 `### ` 标题解析分段,识别失败或旧文档的段落落入默认折叠的"AI 完整报告"兜底区,**旧分析记录仍可正常渲染**(去重/名单/独立作业板块需重新生成后生效)
- 学生名单在生成时批量解析(best-effort,失败不阻塞),存入 summary 文档,前端零额外请求

## Checklist

- [x] `npm run lint` passes(0 errors,警告数与改动前一致)
- [x] `npm test` passes(814 tests,含新增 findingConsolidator 用例与更新的提示词断言)
- [x] `npm run build:plugin` compiles without errors
- [ ] Tested manually with HydroOJ (if applicable) — 本环境无 HydroOJ 运行时,建议部署后"重新生成"一次实际验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174A25JeMuzrPJ5H4FAM9sm

---
_Generated by [Claude Code](https://claude.ai/code/session_0174A25JeMuzrPJ5H4FAM9sm)_