### PR TITLE
fix: restore AI dashboard page structure

### DIFF
--- a/frontend/components/AIHelperDashboard.tsx
+++ b/frontend/components/AIHelperDashboard.tsx
@@ -11,7 +11,7 @@ import { ConfigPanel } from '../admin/ConfigPanel';
 import { SafetyGovernancePanel } from '../admin/SafetyGovernancePanel';
 import { CostDashboard } from '../teacher/CostDashboard';
 import { TeachingReviewPanel } from '../teachingSummary/TeachingReviewPanel';
-import { COLORS, FONT_FAMILY, SPACING } from '../utils/styles';
+import { COLORS, FONT_FAMILY, SHADOWS, RADIUS, SPACING, getTabStyle } from '../utils/styles';
 import { getDomainFromUrl } from '../utils/domainUtils';
 
 type TabType = 'conversations' | 'analytics' | 'teaching_review' | 'cost' | 'safety' | 'config';
@@ -69,28 +69,35 @@ export const AIHelperDashboard: React.FC = () => {
 
   return (
     <div style={{
-      padding: `${SPACING.lg} 0`,
+      padding: SPACING.xl,
       fontFamily: FONT_FAMILY,
-      color: COLORS.nativeText,
+      backgroundColor: COLORS.bgPage,
+      minHeight: '100vh',
     }}>
-      <div style={{ width: '100%' }}>
+      <div style={{ maxWidth: '1200px', margin: '0 auto' }}>
         {/* Dashboard Header */}
         <div style={{
-          padding: `0 0 ${SPACING.lg}`,
+          marginBottom: SPACING.lg,
+          padding: `${SPACING.lg} ${SPACING.xl}`,
+          background: COLORS.bgCard,
+          borderRadius: RADIUS.lg,
+          border: `1px solid ${COLORS.border}`,
+          boxShadow: SHADOWS.sm,
         }}>
-          <h1 style={{ margin: 0, fontSize: '22px', fontWeight: 600, color: COLORS.nativeText }}>
+          <h1 style={{ margin: 0, fontSize: '24px', fontWeight: 700, color: COLORS.textPrimary }}>
             {i18n('ai_helper')}
           </h1>
-          <p style={{ margin: '6px 0 0', color: COLORS.textSecondary, fontSize: '13px' }}>
+          <p style={{ margin: '8px 0 0', color: COLORS.textSecondary, fontSize: '14px' }}>
             {i18n('ai_helper_dashboard_subtitle')}
           </p>
         </div>
 
         {/* Tab Navigation Bar */}
         <div role="tablist" style={{
+          marginBottom: SPACING.lg,
           display: 'flex',
-          gap: 0,
-          borderBottom: `1px solid ${COLORS.nativeBorder}`,
+          gap: SPACING.sm,
+          borderBottom: `2px solid ${COLORS.border}`,
           overflowX: 'auto',
           whiteSpace: 'nowrap',
           WebkitOverflowScrolling: 'touch',
@@ -105,14 +112,9 @@ export const AIHelperDashboard: React.FC = () => {
                 aria-selected={isActive}
                 onClick={() => handleTabChange(tab.id)}
                 style={{
-                  padding: `10px ${SPACING.base}`,
+                  ...getTabStyle(isActive),
                   color: isActive ? COLORS.hydroGreenDark : COLORS.textSecondary,
-                  backgroundColor: 'transparent',
-                  border: 'none',
                   borderBottom: isActive ? `2px solid ${COLORS.hydroGreen}` : '2px solid transparent',
-                  fontSize: '14px',
-                  fontWeight: isActive ? 600 : 400,
-                  cursor: 'pointer',
                   outline: 'none',
                   flexShrink: 0,
                 }}
@@ -126,8 +128,9 @@ export const AIHelperDashboard: React.FC = () => {
         {/* Tab Content Container */}
         <div style={{
           backgroundColor: COLORS.bgCard,
-          border: `1px solid ${COLORS.nativeBorder}`,
-          borderTop: 'none',
+          borderRadius: RADIUS.lg,
+          border: `1px solid ${COLORS.border}`,
+          boxShadow: SHADOWS.sm,
           overflow: 'hidden',
         }}>
           {activeTab === 'conversations' && <ConversationList embedded />}


### PR DESCRIPTION
## What changed

- restore the dashboard's 1200px centered content shell and page padding
- restore the header card, tab spacing, and rounded content container
- keep the redesigned teaching review panel and its existing navigation behavior

## Root cause

The teaching review redesign also flattened the shared `AIHelperDashboard` shell. Because every dashboard tab uses that shell, the AI configuration page was stretched to the full viewport and lost its normal page hierarchy.

## Impact

All AI Helper dashboard tabs again match the established Hydro page structure, while the teaching review content redesign remains intact.

## Validation

- `npm run build:plugin`
- `npm test -- --runInBand` (56 suites, 1134 tests)
- `npm run lint` (0 errors; 65 existing warnings)
- focused frontend TypeScript check
- esbuild bundle of `frontend/ai_helper.page.tsx`
- local browser visual verification at desktop screenshot dimensions